### PR TITLE
Some suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,27 +49,29 @@ Demo Metadata
 If you want to add the metadata in another bundle you can use a metadata processor:
 
 ```python
+@metadata_reactor
 def add_iptables_rule(metadata):
+    iptables_rules = {}
     if node.has_bundle("iptables"):
         interfaces = ['main_interface']
         interfaces += metadata.get('nginx', {}).get('additional_interfaces', [])
 
         for interface in interfaces:
-            metadata += (repo.libs.iptables.accept()
+            metaiptables_rulesdata += (repo.libs.iptables.accept()
                          .input(interface)
                          .state_new()
                          .tcp()
                          .dest_port('80'))
 
-            metadata += (repo.libs.iptables.accept()
+            iptables_rules += (repo.libs.iptables.accept()
                          .input(interface)
                          .state_new()
                          .tcp()
                          .dest_port('443'))
         # ignore this chains
         
-        metadata += repo.libs.iptables.jump('MY_CUSTOM_CHAIN').chain('FORWARD').ignore(),
-        metadata += repo.libs.iptables.ignore_chain('FORWARD'),
+        iptables_rules += repo.libs.iptables.jump('MY_CUSTOM_CHAIN').chain('FORWARD').ignore(),
+        iptables_rules += repo.libs.iptables.ignore_chain('FORWARD'),
         
-    return metadata, True
+    return iptables_rules
 ```

--- a/items.py
+++ b/items.py
@@ -184,10 +184,10 @@ for rule in sorted(node.metadata.get('iptables', {}).get('rules', []), key=repo.
 
     # replace public_interface with configured
     if rule.get('input', '') == 'public_interface':
-        rule_copy['input'] = node.metadata['public_interface']
+        rule_copy['input'] = node.metadata['network']['public_interface']
 
     if rule.get('output', '') == 'public_interface':
-        rule_copy['output'] = node.metadata['public_interface']
+        rule_copy['output'] = node.metadata['network']['public_interface']
 
     # replace source == friendlies with configured networks
     if rule.get('source', "") == "friendlies":

--- a/items/iptables.py
+++ b/items/iptables.py
@@ -222,7 +222,23 @@ def generate_rules_and_chains(table, attributes):
     for chain_name in sorted_chains(table, attributes.get('chains', {}).keys()):
         if is_ignored_chain(chain_name, ignored_chains):
             continue
+        if chain_name != 'LOGDROP':
+            chain = attributes['chains'][chain_name]
+            chains.append(':{chain} {policy}'.format(chain=chain_name, policy=chain.get('policy', '-')))
 
+            for rule in chain.get('rules', []):
+                r, v = generate_rule(chain_name, rule)
+                # ignore Rules
+                if is_ignored_rule(r, ignored_chains, ignored_rules):
+                    continue
+
+                if v == IP_V4 or v == IP_V4_AND_6:
+                    rules_v4.append(r)
+
+                if v == IP_V6 or v == IP_V4_AND_6:
+                    rules_v6.append(r)
+    if sorted_chains(table, attributes.get('chains', {}).keys()).get('LOGDROP'):
+        chain_name = 'LOGDROP'
         chain = attributes['chains'][chain_name]
         chains.append(':{chain} {policy}'.format(chain=chain_name, policy=chain.get('policy', '-')))
 

--- a/items/iptables.py
+++ b/items/iptables.py
@@ -89,6 +89,7 @@ def is_ignored_rule(line, chains, rules):
     for rule in rules:
         line_ignored_by_rule = True
         at_least_one_allowed_key = False
+        allowed_keys['chain'] = '-A {}'
         for key in allowed_keys.keys():
             if key not in rule:
                 continue
@@ -115,6 +116,7 @@ def generate_ignored_rules_and_chains(attributes):
             ignored_chains += [chain_name, ]
 
         for rule in attributes['chains'][chain_name].get('ignored_rules', []):
+            rule['chain'] = chain_name
             ignored_rules += [rule, ]
 
     return ignored_chains, ignored_rules


### PR DESCRIPTION
* README was still in pre v4 form
* the interfaces are (at least in my setup) configured under `network`
* Better identify ignored rules, e.g.:
```
        'iptables': {
            'ignored': {
                'rules': [
                    {'chain': 'DOCKER', 'table': 'filter', 'jump': 'ACCEPT'},
                ]
            }
        }
```
previously ignored all rules with `-j ACCEPT`. Now the chain is also relevant, for more specific ignore rules.
* If the `LOGDROP` rules are not in the last position, `cdict` and `sdict` will never be the same.