### PR TITLE
fix: use qoutes for comments.

### DIFF
--- a/libs/iptables.py
+++ b/libs/iptables.py
@@ -1,4 +1,6 @@
+import re
 from ipaddress import ip_network
+from re import escape
 
 IP_V4 = 4
 IP_V6 = 6
@@ -302,6 +304,11 @@ class IptablesRule(dict):
         return self
 
     def comment(self, comment):
+        if comment[0] != '"':
+            comment = f'"{comment}'
+        if comment[-1] != '"':
+            comment = f'{comment}"'
+
         self['comment'] = comment
 
         return self


### PR DESCRIPTION
When using comments you will most probably not quote them but use spaces inside of it, this will let the iptables run fail.

Example
```
libs.iptables.accept().source('0.0.0.0/0').comment('I do not care')
```
will result in `-A -s 0.0.0.0/0 -m comment --comment I do not care -j ACCEPT` and iptables don't know how to handle `do`.

Of course, we should also handle other special chars, but doing this via `re.escape` we will also escape spaces. -.-