### PR TITLE
fix: don't add quotes to single word comment

### DIFF
--- a/libs/iptables.py
+++ b/libs/iptables.py
@@ -304,9 +304,9 @@ class IptablesRule(dict):
         return self
 
     def comment(self, comment):
-        if comment[0] != '"':
+        if " " in comment and comment[0] != '"':
             comment = f'"{comment}'
-        if comment[-1] != '"':
+        if " "  in comment and comment[-1] != '"':
             comment = f'{comment}"'
 
         self['comment'] = comment
@@ -360,7 +360,7 @@ class IptablesRule(dict):
             metadata['iptables']['rules'].append(self)
 
         return metadata
-    
+
     def __lt__(self, other):
         if isinstance(other, IptablesRule):
             if self.prio_value != other.prio_value:


### PR DESCRIPTION
iptables-save write one-word comments without quotes, this results in failing checks, even when the iptables are correct.